### PR TITLE
No needed of wait for 1 second, already waiting to complete

### DIFF
--- a/main.dart
+++ b/main.dart
@@ -26,7 +26,6 @@ Future<void> main() async {
   await listDatabases();
   await createCollection();
   await listCollection();
-  await Future.delayed(const Duration(seconds: 1));
   await addDoc();
   await listDoc();
   await deleteDoc();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Reduce the wait time in main.dart

Removed the future wait for 1 second in the main.dart main function. Because not need of that wait already its been waiting for future to complete.

## Test Plan

I have changed removed the wait for 1 second in main

## Related PRs and Issues

Issue: #18 
Solved this issue.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.